### PR TITLE
Fix file permissions error in `style-files` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
     hooks:
     -   id: style-files
         args: [--style_pkg=styler, --style_fun=tidyverse_style]
+        require_serial: true
     -   id: use-tidy-description
     -   id: lintr
     -   id: readme-rmd-rendered


### PR DESCRIPTION
This PR implements the same change as https://github.com/ccao-data/model-res-avm/pull/244 in order to fix the same bug in the `pre-commit` workflow. See that PR for more background on this change.

I didn't test timing for serial execution vs parallel execution in the same way that I did in https://github.com/ccao-data/model-res-avm/pull/244 and https://github.com/ccao-data/model-condo-avm/pull/49 since the results of those two PRs have me convinced that serial execution is likely better and at least no worse.