### PR TITLE
Remove string conversion to NA in vars_dict

### DIFF
--- a/python/ccao/vars_funs.py
+++ b/python/ccao/vars_funs.py
@@ -12,6 +12,7 @@ vars_dict = pd.read_csv(
     str(_data_path / "vars_dict.csv"),
     dtype=str,
     keep_default_na=False,
+    na_values=[""],
 )
 
 # Prefix we use to identify variable name columns in the variable dictionary


### PR DESCRIPTION
This PR fixes an NA conversion error that was happening. If we have a string value `"None"` in a csv, in `pandas.read_csv()`, this string value would get converted to a NaN value.